### PR TITLE
TEL-3388: publish artifacts to artifactory

### DIFF
--- a/{{cookiecutter.lambda_name_formatted}}/Makefile
+++ b/{{cookiecutter.lambda_name_formatted}}/Makefile
@@ -72,17 +72,16 @@ prepare_release: ## Runs prepare release
 	@./bin/lambda-tools.sh prepare_release
 .PHONY: prepare_release
 
-publish_artifacts: package ## Build and push lambda zip to S3 (requires MDTP_ENVIRONMENT to be set to an environment)
-	@./bin/lambda-tools.sh publish_artifacts
+publish: publish_to_s3 publish_to_artifactory
 .PHONY: publish_artifacts
 
-publish_artifacts_cip: package ## Build and push lambda zip to CiP (txm) S3 bucket
-	@./bin/lambda-tools.sh publish_artifacts_cip
-.PHONY: publish_artifacts_cip
+publish_to_s3: ## Build and push lambda zip to S3 (requires MDTP_ENVIRONMENT to be set to an environment)
+	@./bin/lambda-tools.sh publish_to_s3
+.PHONY: publish_to_s3
 
-publish_artifacts_mdtp: package ## Build and push lambda zip to MDTP S3 bucket
-	@./bin/lambda-tools.sh publish_artifacts_mdtp
-.PHONY: publish_artifacts_mdtp
+publish_to_artifactory: ## Build and push lambda zip to Artifactory
+	@./bin/lambda-tools.sh publish_to_artifactory
+.PHONY: publish_to_artifactory
 
 safety: ## Run Safety
 	@poetry run safety check
@@ -107,5 +106,5 @@ test: setup ## Run unit tests
 verify: test bandit black safety ## Run all the checks and tests
 .PHONY: verify
 
-verify_publish_release: verify prepare_release publish_artifacts cut_release ## Run all the checks and tests, package, publish_artifacts and release the lambda
+verify_publish_release: verify prepare_release package publish cut_release ## Run all the checks and tests, package, publish and release the lambda
 .PHONY: verify_publish_release


### PR DESCRIPTION
What did we do?
--

1. Removed the code that pushes lambda zip files to S3 buckets other than telemetry lambda artifacts buckets
2. Added code to push lambda zip files to Artifactory

References
--

* https://jira.tools.tax.service.gov.uk/browse/TEL-3388
* https://jira.tools.tax.service.gov.uk/browse/PBD-3935
* https://jira.tools.tax.service.gov.uk/browse/CIE-2301

Evidence of work
--

1. n/a

Next Steps
--

1. Update `aws-lambda-log-handler` to use the latest cookiecutter template
2. Test deployment to Artifactory
3. Roll out changes to all our other lambdas

Risks
--

1. We deploy sensitive lambdas to a location accessible to all engineers on the platform
2. I don't think we have any sensitive lambdas so this is low risk

Collaboration
--

Co-authored-by: Tim Fothergill <67912934+TimothyFothergill@users.noreply.github.com>