### PR TITLE
TEL-3415 add option to upload lambda to CIP s3 bucket

### DIFF
--- a/{{cookiecutter.lambda_name_formatted}}/Makefile
+++ b/{{cookiecutter.lambda_name_formatted}}/Makefile
@@ -79,6 +79,10 @@ publish_to_s3: ## Build and push lambda zip to S3 (requires MDTP_ENVIRONMENT to 
 	@./bin/lambda-tools.sh publish_to_s3
 .PHONY: publish_to_s3
 
+publish_to_cip_s3: ## Build and push lambda zip to CIP S3
+	@./bin/lambda-tools.sh publish_to_cip_s3
+.PHONY: publish_to_cip_s3
+
 publish_to_artifactory: ## Build and push lambda zip to Artifactory
 	@./bin/lambda-tools.sh publish_to_artifactory
 .PHONY: publish_to_artifactory

--- a/{{cookiecutter.lambda_name_formatted}}/buildspec.yml
+++ b/{{cookiecutter.lambda_name_formatted}}/buildspec.yml
@@ -4,6 +4,7 @@ env:
     ARTIFACTORY_TOKEN: /secrets/artifactory-token
   variables:
     MDTP_ENVIRONMENT: "internal-base"
+    PUBLISH_TO_CIP_S3: "false"
 
 # https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html#sample-docker-custom-image-files
 phases:
@@ -15,3 +16,7 @@ phases:
   build:
     commands:
       - make verify_publish_release
+      - |
+        if [ "$PUBLISH_TO_CIP_S3" = "true" ] ; then
+          make publish_to_cip_s3;
+        fi


### PR DESCRIPTION
What did we do?
--

1. Add option to upload lambda to CIP s3 bucket. This will be disabled by default but enabled with an environment variable in the case of log-handler-lambda

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-3415

Evidence of work
--

1. Tested outside of cruft;
![image](https://user-images.githubusercontent.com/18111914/203846399-601515cf-d737-410e-9a10-56619122c286.png)

Next Steps
--

1. update lambda-build to pass in env var to set PUBLISH_TO_CIP_S3 to true for log-handler-lambda

Risks
--

1. CIP explicitly asked us to remove versioning. This is a risk as we are used to using versioning so may be more blaze about new releases. This is a "them" problem :sweat_smile: 
