### PR TITLE
TEL-2490 allow disable of safety

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,5 +6,6 @@
   "lambda_handler": "handler.lambda_handler",
   "lambda_name": null,
   "lambda_name_formatted": "{{ cookiecutter.lambda_name|lower|replace(' ', '-') }}",
+  "safety_disabled": false,
   "unit_test_style": "pytest"
 }

--- a/{{cookiecutter.lambda_name_formatted}}/Makefile
+++ b/{{cookiecutter.lambda_name_formatted}}/Makefile
@@ -88,7 +88,11 @@ publish_to_artifactory: ## Build and push lambda zip to Artifactory
 .PHONY: publish_to_artifactory
 
 safety: ## Run Safety
+{%- if cookiecutter.safety_disabled -%}
+	@echo Safety check is disabled in Cruft configuration
+{%- else -%}
 	@poetry run safety check
+{% endif %}
 .PHONY: safety
 
 setup: check_poetry ## Setup virtualenv & dependencies using poetry and set-up the git hook scripts

--- a/{{cookiecutter.lambda_name_formatted}}/Makefile
+++ b/{{cookiecutter.lambda_name_formatted}}/Makefile
@@ -92,7 +92,7 @@ safety: ## Run Safety
 	@echo Safety check is disabled in Cruft configuration
 {%- else -%}
 	@poetry run safety check
-{% endif %}
+{%- endif -%}
 .PHONY: safety
 
 setup: check_poetry ## Setup virtualenv & dependencies using poetry and set-up the git hook scripts


### PR DESCRIPTION
What we have done
--

Safety is pointing out that an old version of gitpython is installed by the version-incrementor.

This is outside of our control so we are obviating it, hopefully temporarily.

References
--

1. https://jira.tools.tax.service.gov.uk/browse/TEL-2490
2. https://jira.tools.tax.service.gov.uk/browse/PBD-4003 Issue we are working around

Evidence of work
--

1. None

Risks
--

1. Maybe we got the boolean handling wrong in the template?
2. Maybe we'll forget to re-enable this setting?

Next steps
--

1. Apply new config to aws-lambda-telemetry-eventbridge-enrichment and get that tested+merged

Collaborators
--

1. Co-Authored By:  Lee Myring <29373851+thinkstack@users.noreply.github.com>
