### PR TITLE
TEL-3758: add explainer links to the pip install command

### DIFF
--- a/{{cookiecutter.lambda_name_formatted}}/bin/entrypoint.sh
+++ b/{{cookiecutter.lambda_name_formatted}}/bin/entrypoint.sh
@@ -23,6 +23,10 @@ apt-get -y upgrade
 # Install test requirements
 python -m venv "${VENV_NAME}"
 source ./"${VENV_NAME}"/bin/activate
+
+# The platform argument ensures greater compatibility with AWS Lambda Runtimes
+# https://repost.aws/knowledge-center/lambda-python-package-compatible
+# https://github.com/pypa/manylinux - The chosen platform will be EOL June 2024
 pip install --upgrade pip
 pip install --requirement "${REQUIREMENTS_FILE}" \
             --platform manylinux2014_x86_64 \


### PR DESCRIPTION
What did we do?
--

1. Add URL links to the pip install command

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-3758

Collaboration
--

Co-authored-by: Muhammed Ahmed <ma3574@users.noreply.github.com>
