### PR TITLE
TEL-3776 remove acl argument from s3 cp

### DIFF
--- a/{{cookiecutter.lambda_name_formatted}}/Makefile
+++ b/{{cookiecutter.lambda_name_formatted}}/Makefile
@@ -7,6 +7,8 @@ PYTHON_OK := $(shell type -P python)
 PYTHON_REQUIRED := $(shell cat .python-version)
 PYTHON_VERSION ?= $(shell python -V | cut -d' ' -f2)
 
+### WARNING! This is a generated file and should ONLY be edited in https://github.com/hmrc/telemetry-lambda-resources
+
 BUCKET_NAME := {{ cookiecutter.lambda_artifacts_bucket }}
 LAMBDA_NAME := {{ cookiecutter.lambda_name_formatted }}
 TELEMETRY_INTERNAL_BASE_ACCOUNT_ID := 634456480543

--- a/{{cookiecutter.lambda_name_formatted}}/bin/entrypoint.sh
+++ b/{{cookiecutter.lambda_name_formatted}}/bin/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+### WARNING! This is a generated file and should ONLY be edited in https://github.com/hmrc/telemetry-lambda-resources
+
 set -xeu
 
 # Debug Python environment

--- a/{{cookiecutter.lambda_name_formatted}}/bin/lambda-tools.sh
+++ b/{{cookiecutter.lambda_name_formatted}}/bin/lambda-tools.sh
@@ -108,10 +108,8 @@ publish_to_s3() {
   export S3_OBJECT_KEY="${PROJECT_FULL_NAME}.${VERSION}.zip"
   export S3_OBJECT_HASH_KEY="${S3_OBJECT_KEY}.base64sha256"
 
-  aws s3 cp "${PATH_BUILD}/${LAMBDA_ZIP_NAME}" "${S3_ADDRESS}/${S3_OBJECT_KEY}" \
-    --acl=bucket-owner-full-control
+  aws s3 cp "${PATH_BUILD}/${LAMBDA_ZIP_NAME}" "${S3_ADDRESS}/${S3_OBJECT_KEY}"
   aws s3 cp "${PATH_BUILD}/${LAMBDA_HASH_NAME}" "${S3_ADDRESS}/${S3_OBJECT_HASH_KEY}" \
-    --acl=bucket-owner-full-control \
     --content-type text/plain
 
   print_completed
@@ -126,10 +124,8 @@ publish_to_cip_s3() {
   export S3_OBJECT_HASH_KEY="${S3_OBJECT_KEY}.base64sha256"
 
   for account in integration qa externaltest staging production ; do
-    aws s3 cp "${PATH_BUILD}/${LAMBDA_ZIP_NAME}" s3://txm-lambda-functions-${account}/log_handler.zip \
-      --acl=bucket-owner-full-control
+    aws s3 cp "${PATH_BUILD}/${LAMBDA_ZIP_NAME}" s3://txm-lambda-functions-${account}/log_handler.zip
     aws s3 cp "${PATH_BUILD}/${LAMBDA_HASH_NAME}" s3://txm-lambda-functions-${account}/log_handler.zip.base64sha256 \
-      --acl=bucket-owner-full-control \
       --content-type text/plain
   done
 

--- a/{{cookiecutter.lambda_name_formatted}}/bin/lambda-tools.sh
+++ b/{{cookiecutter.lambda_name_formatted}}/bin/lambda-tools.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+### WARNING! This is a generated file and should ONLY be edited in https://github.com/hmrc/telemetry-lambda-resources
+
 # A helper tool to assist us maintaining lambda functions
 # Intention here is to keep this files and all its functions reusable for all Telemetry repositories
 

--- a/{{cookiecutter.lambda_name_formatted}}/bin/package-lambda.sh
+++ b/{{cookiecutter.lambda_name_formatted}}/bin/package-lambda.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+### WARNING! This is a generated file and should ONLY be edited in https://github.com/hmrc/telemetry-lambda-resources
+
 set -eu
 
 apt install -y libssl-dev zip

--- a/{{cookiecutter.lambda_name_formatted}}/bin/run-tests.sh
+++ b/{{cookiecutter.lambda_name_formatted}}/bin/run-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+### WARNING! This is a generated file and should ONLY be edited in https://github.com/hmrc/telemetry-lambda-resources
+
 set -eu
 
 export LOG_LEVEL="DEBUG"

--- a/{{cookiecutter.lambda_name_formatted}}/buildspec.yml
+++ b/{{cookiecutter.lambda_name_formatted}}/buildspec.yml
@@ -1,4 +1,7 @@
 version: 0.2
+
+### WARNING! This is a generated file and should ONLY be edited in https://github.com/hmrc/telemetry-lambda-resources
+
 env:
   variables:
     MDTP_ENVIRONMENT: "internal-base"

--- a/{{cookiecutter.lambda_name_formatted}}/buildspec_pr.yml
+++ b/{{cookiecutter.lambda_name_formatted}}/buildspec_pr.yml
@@ -1,4 +1,7 @@
 version: 0.2
+
+### WARNING! This is a generated file and should ONLY be edited in https://github.com/hmrc/telemetry-lambda-resources
+
 env:
   variables:
     MDTP_ENVIRONMENT: "internal-base"

--- a/{{cookiecutter.lambda_name_formatted}}/tools/check-tool-versions.sh
+++ b/{{cookiecutter.lambda_name_formatted}}/tools/check-tool-versions.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+### WARNING! This is a generated file and should ONLY be edited in https://github.com/hmrc/telemetry-lambda-resources
+
 # Ensure .tool-versions (ASDF) and .<tool>-version (individual version managers) are referencing same version
 
 # Variables


### PR DESCRIPTION
What did we do?
--

- TEL-3776: add warnings about generated files
- TEL-3776: remove s3 cp --acl argument


References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-3776

Evidence of work
--

When we removed the argument the build started passing and the S3 object was visible

![image](https://github.com/hmrc/telemetry-lambda-resources/assets/29373851/d1b0fc47-6101-4d17-90e8-fbe569ab3490)


Next Steps
--

1. Update all lambdas with latest cruft version

Risks
--

1. none

Collaboration
--

Co-authored-by: Rizina Khatun <66684341+rizinaa99@users.noreply.github.com>
