### PR TITLE
TEL-3776 set bucket owner ACL when uploading to CIP buckets

### DIFF
--- a/{{cookiecutter.lambda_name_formatted}}/bin/lambda-tools.sh
+++ b/{{cookiecutter.lambda_name_formatted}}/bin/lambda-tools.sh
@@ -124,8 +124,10 @@ publish_to_cip_s3() {
   export S3_OBJECT_HASH_KEY="${S3_OBJECT_KEY}.base64sha256"
 
   for account in integration qa externaltest staging production ; do
-    aws s3 cp "${PATH_BUILD}/${LAMBDA_ZIP_NAME}" s3://txm-lambda-functions-${account}/log_handler.zip
+    aws s3 cp "${PATH_BUILD}/${LAMBDA_ZIP_NAME}" s3://txm-lambda-functions-${account}/log_handler.zip \
+      --acl=bucket-owner-full-control
     aws s3 cp "${PATH_BUILD}/${LAMBDA_HASH_NAME}" s3://txm-lambda-functions-${account}/log_handler.zip.base64sha256 \
+      --acl=bucket-owner-full-control \
       --content-type text/plain
   done
 


### PR DESCRIPTION
What did we do?
--

1. Set acl=bucket-owner-full-control as CIP buckets do not have Bucket Owner enforced property, so they cannot access objects uploaded from external accounts

References
--

https://hmrcdigital.slack.com/archives/G0JJ0ADLY/p1668602134071319
https://jira.tools.tax.service.gov.uk/browse/TEL-3776

Evidence of work
--

1. Tested on a branch, see slack thread for confirmation that this resolves the issue

Next Steps
--

1. cruft update on all the lambdas

