### PR TITLE
TEL-4180 use artifactory for python dependencies when running pre-commit

### DIFF
--- a/{{cookiecutter.lambda_name_formatted}}/Dockerfile
+++ b/{{cookiecutter.lambda_name_formatted}}/Dockerfile
@@ -4,10 +4,11 @@ RUN yum install ca-certificates -y
 
 COPY requirements.txt requirements-tests.txt setup.cfg ${LAMBDA_TASK_ROOT}/
 
-RUN python -m venv venv && \
-  source ./venv/bin/activate && \
-  pip install --upgrade pip && \
-  pip install --requirement requirements-tests.txt --target "${LAMBDA_TASK_ROOT}"
+RUN PIP_INDEX_URL=https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple \
+    python -m venv venv && \
+    source ./venv/bin/activate && \
+    pip install --upgrade pip && \
+    pip install --requirement requirements-tests.txt --target "${LAMBDA_TASK_ROOT}"
 
 COPY src tests ${LAMBDA_TASK_ROOT}/
 

--- a/{{cookiecutter.lambda_name_formatted}}/bin/entrypoint.sh
+++ b/{{cookiecutter.lambda_name_formatted}}/bin/entrypoint.sh
@@ -29,8 +29,9 @@ source ./"${VENV_NAME}"/bin/activate
 # The platform argument ensures greater compatibility with AWS Lambda Runtimes
 # https://repost.aws/knowledge-center/lambda-python-package-compatible
 # https://github.com/pypa/manylinux - The chosen platform will be EOL June 2024
-pip install --upgrade pip
-pip install --requirement "${REQUIREMENTS_FILE}" \
+pip install --index-url https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple --upgrade pip
+pip install --index-url https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple \
+            --requirement "${REQUIREMENTS_FILE}" \
             --platform manylinux2014_x86_64 \
             --target=./${VENV_NAME}/lib/python{{ cookiecutter.python_version }}/site-packages \
             --implementation cp \

--- a/{{cookiecutter.lambda_name_formatted}}/buildspec_pr.yml
+++ b/{{cookiecutter.lambda_name_formatted}}/buildspec_pr.yml
@@ -15,5 +15,5 @@ phases:
       - make setup
   build:
     commands:
-      - pre-commit run --all-files --verbose
+      - PIP_INDEX_URL=https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple pre-commit run --all-files --verbose
       - make verify


### PR DESCRIPTION
What did we do?
--

1. TEL-4180 use artifactory for python dependencies when running pre-commit

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4180

Next Steps
--

1. Update cruft in all the lambda repos

Risks
--

1. Haven't been able to test this

Collaboration
--

Co-authored-by: Muhammed Ahmed <ma3574@users.noreply.github.com>

