### PR TITLE
TEL-4439 Skip flake8 E203 check

### DIFF
--- a/{{cookiecutter.lambda_name_formatted}}/setup.cfg
+++ b/{{cookiecutter.lambda_name_formatted}}/setup.cfg
@@ -13,7 +13,7 @@ max-line-length = 120
 
 [flake8]
 {% if cookiecutter.flake8_extra_skip_tests is defined -%}
-ignore = E501, W503{{cookiecutter.flake8_extra_skip_tests}}
+ignore = E501, W503, E203{{cookiecutter.flake8_extra_skip_tests}}
 {%- else -%}
-ignore = E501, W503
+ignore = E501, W503, E203
 {%- endif %}


### PR DESCRIPTION
What did we do?
--

The flake8 E203 check states that _Colons should not have any space before them._

However we run Black as part of our pre-commit, and it enforces that colons _should_ have whitespace before them!

It is recommended here that the appropriate thing to do is to prefer Black to Flake8 for style changes. https://github.com/psf/black/issues/315

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4439

Evidence of work
--

1. The PR

Next Steps
--

1. Merge

Risks
--

1. ?

