### PR TITLE
TEL-4536 Fix pythonpath for pytest

### DIFF
--- a/{{cookiecutter.lambda_name_formatted}}/pytest.ini
+++ b/{{cookiecutter.lambda_name_formatted}}/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 log_cli = True
 log_cli_level = INFO
+pythonpath = . src


### PR DESCRIPTION
What did we do?
--

1. Updated python path as [per this answer](https://stackoverflow.com/a/50610630), to stop import shenanigans. 
The problem I was trying to solve is:

- src/foo
- src/bah/hello
- tests/unit/test-foo

In a final packaged lambda artefact, there will be no 'src', instead 'foo' will be at the root level of the package, so within the foo module, in order to import `hello`, the import path cannot contain 'src'. Otherwise there will be a runtime error.
So the import will be `from bah import hello`.

However, in test-foo, this will result in an import error when running pytest, as it doesn't know that blah.hello sits inside 'src'.

Hope that makes sense....

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4536

Risks
--

1. Outside of single file scripts, I'm a bit of a python noob. (BUT LOOK AT THE UPVOTES ON STACKOVERFLOW!!)

