### PR TITLE
TEL-4464 override PYTHON_VERSION env var inside makefile

### DIFF
--- a/{{cookiecutter.lambda_name_formatted}}/Makefile
+++ b/{{cookiecutter.lambda_name_formatted}}/Makefile
@@ -5,7 +5,7 @@ POETRY_REQUIRED := $(shell cat .poetry-version)
 POETRY_VIRTUALENVS_IN_PROJECT ?= true
 PYTHON_OK := $(shell type -P python)
 PYTHON_REQUIRED := $(shell cat .python-version | cut -d'.' -f1,2)
-PYTHON_VERSION ?= $(shell python --version | cut -d' ' -f2 | cut -d'.' -f1,2)
+PYTHON_VERSION := $(shell python --version | cut -d' ' -f2 | cut -d'.' -f1,2)
 
 ### WARNING! This is a generated file and should ONLY be edited in https://github.com/hmrc/telemetry-lambda-resources
 


### PR DESCRIPTION
What did we do?
--

1. Changed the assignment of PYTHON_VERSION in the Makefile to ensure that it always gets set. For some reason PYTHON_VERSION was using ?= which is a **_conditional_** assignment which only gets set if it isn't already set (and it is already set, but not the thing we want it to be!

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4464

Evidence of work
--

1. Before making change:
<img width="675" alt="image" src="https://github.com/user-attachments/assets/8473cdc1-d1a8-4f4c-ad2b-b89782a9a316">

2. After making change:
<img width="339" alt="image" src="https://github.com/user-attachments/assets/28bc4786-d9d1-459c-a2ed-1bbe0ea37789">
