### PR TITLE
TEL-4464 upgrade lambda package container from buster to bookworm

### DIFF
--- a/{{cookiecutter.lambda_name_formatted}}/bin/entrypoint.sh
+++ b/{{cookiecutter.lambda_name_formatted}}/bin/entrypoint.sh
@@ -13,8 +13,7 @@ BASEDIR=/data
 cd ${BASEDIR}
 
 # Force Debian to use HTTPS
-cp /etc/apt/sources.list /etc/apt/sources.list.bak
-sed --in-place 's|http://|https://|g' /etc/apt/sources.list
+sed --in-place 's|http://|https://|g' /etc/apt/sources.list.d/debian.sources
 
 # Update the package listing, so we know what package exist:
 apt-get update

--- a/{{cookiecutter.lambda_name_formatted}}/bin/lambda-tools.sh
+++ b/{{cookiecutter.lambda_name_formatted}}/bin/lambda-tools.sh
@@ -42,7 +42,7 @@ open_shell() {
                --workdir /data \
                --env REQUIREMENTS_FILE="requirements-tests.txt" \
                --env VENV_NAME="venv" \
-               python:$(cat "${BASE_LOCATION}/.python-version")-slim-buster /data/bin/entrypoint.sh /bin/bash
+               python:$(cat "${BASE_LOCATION}/.python-version")-slim-bookworm /data/bin/entrypoint.sh /bin/bash
 
     print_completed
 }
@@ -58,7 +58,7 @@ unittest() {
              --workdir /data \
              --env REQUIREMENTS_FILE="requirements-tests.txt" \
              --env VENV_NAME="venv" \
-             python:$(cat "${BASE_LOCATION}/.python-version")-slim-buster /data/bin/entrypoint.sh /data/bin/run-tests.sh
+             python:$(cat "${BASE_LOCATION}/.python-version")-slim-bookworm /data/bin/entrypoint.sh /data/bin/run-tests.sh
 
   print_completed
 }
@@ -76,7 +76,7 @@ package() {
              --env LAMBDA_HASH_NAME="${LAMBDA_HASH_NAME}" \
              --env REQUIREMENTS_FILE="requirements.txt" \
              --env VENV_NAME="venv_package" \
-             python:$(cat "${BASE_LOCATION}/.python-version")-slim-buster /data/bin/entrypoint.sh /data/bin/package-lambda.sh
+             python:$(cat "${BASE_LOCATION}/.python-version")-slim-bookworm /data/bin/entrypoint.sh /data/bin/package-lambda.sh
 
   print_completed
 }


### PR DESCRIPTION
What did we do?
--

1. Upgraded the lambda package container from buster to bookworm

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4464

Evidence of work
--

1. Tested `make verify` in a telemetry lambda locally

Next Steps
--

1. I'm not sure why we don't just use the telemetry-build-container for this, but this ticket is already big enough as it is

Risks
--

1. Fairly untested change
